### PR TITLE
Image processing fix

### DIFF
--- a/liboptv/src/image_processing.c
+++ b/liboptv/src/image_processing.c
@@ -59,6 +59,12 @@ int filter_3(unsigned char *img, unsigned char *img_lp, filter_t filt,
             sum += filt[i][j];
     if (sum == 0) return 0;
     
+    /* initialize the img_lp with zeros */
+    for (i=0;i<cpar->imx;i++)
+        for(j=0;j<cpar->imy;j++)
+            img_lp[i*cpar->imx+j] = 0;
+            
+    
     /* start, end etc skip first/last lines and wrap around the edges. */
     end = image_size - cpar->imx - 1;
     
@@ -93,11 +99,17 @@ void lowpass_3(unsigned char *img, unsigned char *img_lp, control_par *cpar) {
         *ptr7, *ptr8, *ptr9;
     int end;
     short buf;
-    register int i;
+    register int i,j;
     int image_size = cpar->imx * cpar->imy;
     
     /* start, end etc skip first/last lines and wrap around the edges. */
     end = image_size - cpar->imx - 1;
+    
+    /* initialize the img_lp with zeros */
+    for (i=0;i<cpar->imx;i++)
+        for(j=0;j<cpar->imy;j++)
+            img_lp[i*cpar->imx+j] = 0;
+
     
     setup_filter_pointers(cpar->imx)
     for (i = cpar->imx + 1; i < end; i++) {

--- a/liboptv/tests/CMakeLists.txt
+++ b/liboptv/tests/CMakeLists.txt
@@ -35,6 +35,11 @@ if (UNIX)
     set(LIBS ${LIBS} -lm -pthread)
 endif (UNIX)
 
+if (APPLE)
+    set(LIBS ${LIBS} -L/usr/local/lib)
+endif (APPLE)
+
+
 target_link_libraries(check_fb ${LIBS})
 add_test(check_fb ${CMAKE_CURRENT_BINARY_DIR}/check_fb)
 


### PR DESCRIPTION
For whatever reason the allocation of img_lp is not initialising it with zeros. The suggested fix is consistent with all platforms and it manually initialises the img_lp with zeros inside lowpass_3 and filter_3 (although it repeats the code)

    /* initialize the img_lp with zeros */
    for (i=0;i<cpar->imx;i++)
        for(j=0;j<cpar->imy;j++)
            img_lp[i*cpar->imx+j] = 0;


